### PR TITLE
upgrade mongoshell_package for 4.2 as 4.2.10 had few library errors

### DIFF
--- a/pre-5.0/docker-build.sh
+++ b/pre-5.0/docker-build.sh
@@ -7,7 +7,7 @@ if [[ $1 = "4.0" ]]; then
   docker build -f Dockerfile-$1 --build-arg version=$1 --build-arg branch=$branch --build-arg mongoshell_package=$mongoshell_package -t mongo/mongodb-tests:$1 .
 elif [[ $1 = "4.2" ]]; then
   branch=v4.2
-  mongoshell_package=debian10-4.2.10
+  mongoshell_package=debian10-4.2.22
   docker build -f Dockerfile --build-arg version=$1 --build-arg branch=$branch --build-arg mongoshell_package=$mongoshell_package -t mongo/mongodb-tests:$1 .
 elif [[ $1 = "4.4" ]]; then
   branch=v4.4


### PR DESCRIPTION
upgraded from 4.2.10 to 4.2.22.

This is required because on 4.2.10, function `numberDecimalsEqual` is missing.

```
[js_test:decimal_constructors] 2024-09-18T19:58:35.114+0000 2024-09-18T19:58:35.114+0000 E  QUERY    [js] uncaught exception: ReferenceError: numberDecimalsEqual is not defined :
[js_test:decimal_constructors] 2024-09-18T19:58:35.114+0000 @jstests/decimal/decimal_constructors.js:46:1
```