### PR TITLE
make 5.0 tests run

### DIFF
--- a/post-5.0/Dockerfile
+++ b/post-5.0/Dockerfile
@@ -13,10 +13,6 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /mongodb-shell-linux-x86_64-$mongoshell_package.tgz
 COPY entrypoint.sh /entrypoint.sh
 COPY test-suites/$version/* /mongo/buildscripts/resmokeconfig/suites/
-RUN rm -f /mongo/buildscripts/resmokelib/testing/testcases/jstest.py
-COPY jstest.py /mongo/buildscripts/resmokelib/testing/testcases/
-RUN rm -f /mongo/buildscripts/resmokelib/testing/testcases/interface.py
-COPY interface.py.v5.1 /mongo/buildscripts/resmokelib/testing/testcases/interface.py
 #COPY mongo /mongoShell/
 #ENV m=/mongoShell/mongo
 ENV m=/mongodb-linux-x86_64-$mongoshell_package/bin/mongo

--- a/post-5.0/docker-build.sh
+++ b/post-5.0/docker-build.sh
@@ -3,7 +3,7 @@
 #linux shell files at https://www.mongodb.org/dl/linux/x86_64
 if [[ $1 = "5.0" ]]; then
   branch=v5.0
-  mongoshell_package=debian10-5.0.0
+  mongoshell_package=debian10-5.0.27
   docker build -f Dockerfile --build-arg version=$1 --build-arg branch=$branch --build-arg mongoshell_package=$mongoshell_package -t mongo/mongodb-tests:$1 .
 elif [[ $1 = "5.1" ]]; then
   branch=v5.1

--- a/post-5.0/test-suites/5.0/dbaas_core.yml
+++ b/post-5.0/test-suites/5.0/dbaas_core.yml
@@ -37,7 +37,6 @@ selector:
   - jstests/core/queryoptimizera.js
   - jstests/core/read_after_optime.js
   - jstests/core/roles_info.js
-  - jstests/core/timeseries/timeseries_idle_buckets.js
   - jstests/core/timeseries/timeseries_index_stats.js
   - jstests/core/validate_db_metadata_command.js
   - jstests/core/version_api_list_commands_verification.js


### PR DESCRIPTION
- default interface.py just worked fine
- debian10-5.0.27 has additional required js functions which are missing in old one
- there is no file jstests/core/timeseries/timeseries_idle_buckets.js in 5.0 repo